### PR TITLE
Remove ambiguous LQREGIONS

### DIFF
--- a/BAM.rst
+++ b/BAM.rst
@@ -213,7 +213,7 @@ SAM/BAM spec, we encode special information as follows.
       +-------------------+----------------------------------------+----------------+
       | Key               | Value spec                             | Value example  |
       +===================+========================================+================+
-      | READTYPE          | One of POLYMERASE, HQREGION, LQREGION, | SUBREAD        |
+      | READTYPE          | One of POLYMERASE, HQREGION,           | SUBREAD        |
       |                   | SUBREAD, CCS, SCRAP, or UNKNOWN        |                |
       +-------------------+----------------------------------------+----------------+
       | BINDINGKIT        | Binding kit part number                | 100236500      |


### PR DESCRIPTION
LQREGIONS were supported by READTYPE and scrap tag sc:A:L.
Remove the READTYPE to have _one_ way support.